### PR TITLE
tunnel fix and escape test

### DIFF
--- a/narrator/parser.lua
+++ b/narrator/parser.lua
@@ -54,7 +54,7 @@ function Parser.parse(content)
   -- TODO: Clean divert expression to divert and tunnel
   local divert = divertSign * sp * Cg(address, 'path') -- base search for divert symbol and path to follow
   local checkTunnel = Cg(Cmt(Cb('path'), function(s, i, a) local r = lpeg.match (sp * divertSign, s, i) return i, r ~= nil end),'tunnel') -- a weird way to to check tunnel
-  local optTunnelSign = (sp * divertSign * #nl ) ^ -1 -- tunnel sign in end of string, keep newline not consumed
+  local optTunnelSign = (sp * divertSign * sp * #nl ) ^ -1 -- tunnel sign in end of string, keep newline not consumed
   divert = Cg(Ct(divert * sp * checkTunnel * optTunnelSign), 'divert')
   
   local divertToNothing = divertSign * none

--- a/test/cases.lua
+++ b/test/cases.lua
@@ -50,6 +50,7 @@ local units = {
   'lists-queries',
 
   'tunnels',
+  'escape',
 }
 
 local stories = {

--- a/test/units/escape.ink
+++ b/test/units/escape.ink
@@ -1,0 +1,1 @@
+The \| dark \{grass\} is soft under your feet.

--- a/test/units/escape.txt
+++ b/test/units/escape.txt
@@ -1,0 +1,1 @@
+The | dark {grass} is soft under your feet.

--- a/test/units/tunnels.ink
+++ b/test/units/tunnels.ink
@@ -6,7 +6,8 @@ The dark grass is soft under your feet.
 	wtf
 }
 
-It is time to move on.
+->move_on-> 
+
 -> END
 
 === wake_here ===
@@ -20,3 +21,6 @@ You lie down and try to close your eyes.
 === dream ===
 You dream about the dream.
 ->->
+
+=== move_on
+It is time to move on. ->->


### PR DESCRIPTION
escape test is failed, looks like we need  to modify S'{|}' in parser line 172 to avoid the case with \ before {|} symbols

